### PR TITLE
Add wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ to start the container with `rvw` installed.  See the
 [Boettiger and Eddelbuettel RJournal paper](https://journal.r-project.org/archive/2017/RJ-2017-065/index.html)
 for more on Docker for R, and the [Rocker Project](https://www.rocker-project.org) used here.
 
+## Getting Started
+[Introduction](https://github.com/rvw-org/rvw/wiki/Introduction)
+
+Examples:
+
+* [Binary classification](https://github.com/rvw-org/rvw/wiki/Binary-classification)
+* [CSOAA multiclass classification](https://github.com/rvw-org/rvw/wiki/CSOAA-multiclass-classification)
+* [Topic modeling with Latent Dirichlet Allocation (LDA)](https://github.com/rvw-org/rvw/wiki/Topic-modeling-with-Latent-Dirichlet-Allocation-(LDA))
+
+
 ## Example 
 
 In this example we will try to predict age groups (based on number of abalone shell rings) from physical measurements. We will use Abalone Data Set from [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/Abalone).


### PR DESCRIPTION
I've reviewed our current state.
`R CMD check`  seems to be clean for me.

Added pages to wiki based on a vignette and demos

I've tested some learning modes and found a few issues:
- `interactions` from VW (as well as `quadratic ` and `cubic`) support only one option when using regular rvw interface. 
So several namespace interactions at the same time (like this `--interactions ud ab ca`) are not possible. However, this is working through the command line interface of rvw.
- Active learning is not fully supported right now (e.g. `--active`). This often requires setting up a daemon.
